### PR TITLE
update README to use the non deprecated createTRPCProxyClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ createChromeHandler({
 
 ```typescript
 // content.ts
-import { createTRPCClient } from '@trpc/client';
+import { createTRPCProxyClient } from '@trpc/client';
 import { chromeLink } from 'trpc-chrome/link';
 
 import type { AppRouter } from './background';
 
 const port = chrome.runtime.connect();
-export const chromeClient = createTRPCClient<AppRouter>({
+export const chromeClient = createTRPCProxyClient<AppRouter>({
   links: [/* 👉 */ chromeLink({ port })],
 });
 ```


### PR DESCRIPTION
This change is tiny but I ran into it when checking out the README so thought I'd throw our a PR.

The README uses `createTRPCClient` which has been deprecated in favor of `createTRPCProxyClient`. This is the call that is also used in the examples.

For consistency, just switch to the non deprecated function `createTRPCProxyClient`.