### PR TITLE
fixes #14 add transformer serialization to emitted data in subscription routes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,10 +5,6 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true
   },
-  "workbench.colorCustomizations": {
-    "titleBar.activeBackground": "#1a73e8",
-    "titleBar.inactiveBackground": "#5a98e9"
-  },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -128,14 +128,16 @@ export const createChromeHandler = <TRouter extends AnyRouter>(
               req: port,
             });
 
+            const shapedError = router.getErrorShape({
+              error,
+              type: method,
+              path: params?.path,
+              input,
+              ctx,
+            });
+            const serializedError = transformer.output.serialize(shapedError);
             sendResponse({
-              error: router.getErrorShape({
-                error,
-                type: method,
-                path: params?.path,
-                input,
-                ctx,
-              }),
+              error: serializedError,
             });
           },
           complete: () => {
@@ -181,14 +183,16 @@ export const createChromeHandler = <TRouter extends AnyRouter>(
           req: port,
         });
 
+        const shapedError = router.getErrorShape({
+          error,
+          type: method as ProcedureType,
+          path: params?.path,
+          input,
+          ctx,
+        });
+        const serializedError = transformer.output.serialize(shapedError);
         sendResponse({
-          error: router.getErrorShape({
-            error,
-            type: method as ProcedureType,
-            path: params?.path,
-            input,
-            ctx,
-          }),
+          error: serializedError,
         });
       }
     };

--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -108,10 +108,11 @@ export const createChromeHandler = <TRouter extends AnyRouter>(
 
         const subscription = result.subscribe({
           next: (data) => {
+            const serializedData = transformer.output.serialize(data);
             sendResponse({
               result: {
                 type: 'data',
-                data,
+                data: serializedData,
               },
             });
           },

--- a/test/webextWTransfromer.test.ts
+++ b/test/webextWTransfromer.test.ts
@@ -1,7 +1,7 @@
 import { resetMocks } from './__setup';
 
-import { createTRPCProxyClient } from '@trpc/client';
-import { initTRPC } from '@trpc/server';
+import { TRPCClientError, createTRPCProxyClient } from '@trpc/client';
+import { TRPCError, initTRPC } from '@trpc/server';
 import { Unsubscribable, observable } from '@trpc/server/observable';
 import superjson from 'superjson';
 import { z } from 'zod';
@@ -30,9 +30,37 @@ const appRouter = t.router({
       }),
     ),
 
-  echoTransformerQuery: t.procedure
-    .input(z.object({ payload: z.date() }))
-    .query(({ input }) => input),
+  throwQuery: t.procedure.input(z.object({ payload: z.string() })).query(({ input }) => {
+    throw new Error(input.payload);
+    return input;
+  }),
+  throwTrpcErrorQuery: t.procedure.input(z.object({ payload: z.string() })).query(({ input }) => {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: input.payload });
+  }),
+  throwMutation: t.procedure.input(z.object({ payload: z.string() })).mutation(({ input }) => {
+    throw new Error(input.payload);
+  }),
+  throwTrpcErrorMutation: t.procedure
+    .input(z.object({ payload: z.string() }))
+    .mutation(({ input }) => {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: input.payload });
+    }),
+
+  throwSubscription: t.procedure
+    .input(z.object({ payload: z.string() }))
+    .subscription(({ input }) =>
+      observable<typeof input>((emit) => {
+        throw new TRPCError({ message: input.payload, code: 'BAD_REQUEST' });
+        emit.next(input);
+      }),
+    ),
+  errorSubscription: t.procedure
+    .input(z.object({ payload: z.string() }))
+    .subscription(({ input }) =>
+      observable<typeof input>((emit) => {
+        emit.error(new TRPCError({ message: input.payload, code: 'BAD_REQUEST' }));
+      }),
+    ),
 
   nestedRouter: t.router({
     echoQuery: t.procedure
@@ -89,6 +117,52 @@ test('with query', async () => {
   expect(data4).toEqual({ payload: 'query4', date: date4 });
 });
 
+test('throw error with query', async () => {
+  // background
+  createChromeHandler({ router: appRouter });
+  expect(chrome.runtime.onConnect.addListener).toHaveBeenCalledTimes(1);
+
+  // content
+  const port = chrome.runtime.connect();
+  const trpc = createTRPCProxyClient<typeof appRouter>({
+    links: [chromeLink({ port })],
+    transformer: superjson,
+  });
+
+  try {
+    await trpc.throwQuery.query({ payload: 'i error' });
+    fail('has to throw');
+  } catch (e) {
+    expect(e).toBeInstanceOf(TRPCClientError);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const castError = e as TRPCClientError<any>;
+    expect(castError.message).toEqual('i error');
+  }
+});
+
+test('throw trpc error with query', async () => {
+  // background
+  createChromeHandler({ router: appRouter });
+  expect(chrome.runtime.onConnect.addListener).toHaveBeenCalledTimes(1);
+
+  // content
+  const port = chrome.runtime.connect();
+  const trpc = createTRPCProxyClient<typeof appRouter>({
+    links: [chromeLink({ port })],
+    transformer: superjson,
+  });
+
+  try {
+    await trpc.throwTrpcErrorQuery.query({ payload: 'i error' });
+    fail('has to throw');
+  } catch (e) {
+    expect(e).toBeInstanceOf(TRPCClientError);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const castError = e as TRPCClientError<any>;
+    expect(castError.message).toEqual('i error');
+  }
+});
+
 test('with mutation', async () => {
   // background
   createChromeHandler({ router: appRouter });
@@ -121,6 +195,52 @@ test('with mutation', async () => {
   ]);
   expect(data3).toEqual({ payload: 'mutation3', date: date3 });
   expect(data4).toEqual({ payload: 'mutation4', date: date4 });
+});
+
+test('throw error with mutation', async () => {
+  // background
+  createChromeHandler({ router: appRouter });
+  expect(chrome.runtime.onConnect.addListener).toHaveBeenCalledTimes(1);
+
+  // content
+  const port = chrome.runtime.connect();
+  const trpc = createTRPCProxyClient<typeof appRouter>({
+    links: [chromeLink({ port })],
+    transformer: superjson,
+  });
+
+  try {
+    await trpc.throwMutation.mutate({ payload: 'I mutated' });
+    fail('has to throw');
+  } catch (e) {
+    expect(e).toBeInstanceOf(TRPCClientError);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const castError = e as TRPCClientError<any>;
+    expect(castError.message).toEqual('I mutated');
+  }
+});
+
+test('throw trpc error with mutation', async () => {
+  // background
+  createChromeHandler({ router: appRouter });
+  expect(chrome.runtime.onConnect.addListener).toHaveBeenCalledTimes(1);
+
+  // content
+  const port = chrome.runtime.connect();
+  const trpc = createTRPCProxyClient<typeof appRouter>({
+    links: [chromeLink({ port })],
+    transformer: superjson,
+  });
+
+  try {
+    await trpc.throwTrpcErrorMutation.mutate({ payload: 'I mutated trpc' });
+    fail('has to throw');
+  } catch (e) {
+    expect(e).toBeInstanceOf(TRPCClientError);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const castError = e as TRPCClientError<any>;
+    expect(castError.message).toEqual('I mutated trpc');
+  }
 });
 
 test('with subscription', async () => {
@@ -170,6 +290,103 @@ test('with subscription', async () => {
   expect(onErrorMock).toHaveBeenCalledTimes(0);
   expect(onStartedMock).toHaveBeenCalledTimes(1);
   expect(onStoppedMock).toHaveBeenCalledTimes(1);
+});
+
+test('with error subscription', async () => {
+  // background
+  createChromeHandler({ router: appRouter });
+  expect(chrome.runtime.onConnect.addListener).toHaveBeenCalledTimes(1);
+
+  // content
+  const port = chrome.runtime.connect();
+  const trpc = createTRPCProxyClient<typeof appRouter>({
+    links: [chromeLink({ port })],
+    transformer: superjson,
+  });
+
+  const onDataMock = jest.fn();
+  const onCompleteMock = jest.fn();
+  const onErrorMock = jest.fn();
+  const onStartedMock = jest.fn();
+  const onStoppedMock = jest.fn();
+
+  const subscription = await new Promise<Unsubscribable>((resolve) => {
+    const subscription = trpc.errorSubscription.subscribe(
+      { payload: 'subscription1' },
+      {
+        onData: onDataMock,
+        onComplete: onCompleteMock,
+        onError: (error) => {
+          onErrorMock(error);
+          resolve(subscription);
+        },
+        onStarted: onStartedMock,
+        onStopped: onStoppedMock,
+      },
+    );
+  });
+  expect(onDataMock).toHaveBeenCalledTimes(0);
+  expect(onCompleteMock).toHaveBeenCalledTimes(0);
+  expect(onErrorMock).toHaveBeenCalledTimes(1);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  expect(onErrorMock.mock.calls[0][0].message).toEqual('subscription1');
+  expect(onStartedMock).toHaveBeenCalledTimes(0);
+  expect(onStoppedMock).toHaveBeenCalledTimes(0);
+  subscription.unsubscribe();
+  expect(onDataMock).toHaveBeenCalledTimes(0);
+  expect(onCompleteMock).toHaveBeenCalledTimes(0);
+  expect(onErrorMock).toHaveBeenCalledTimes(1);
+  expect(onStartedMock).toHaveBeenCalledTimes(0);
+  expect(onStoppedMock).toHaveBeenCalledTimes(0);
+});
+
+test('with throw subscription', async () => {
+  // background
+  createChromeHandler({ router: appRouter });
+  expect(chrome.runtime.onConnect.addListener).toHaveBeenCalledTimes(1);
+
+  // content
+  const port = chrome.runtime.connect();
+  const trpc = createTRPCProxyClient<typeof appRouter>({
+    links: [chromeLink({ port })],
+    transformer: superjson,
+  });
+
+  const onDataMock = jest.fn();
+  const onCompleteMock = jest.fn();
+  const onErrorMock = jest.fn();
+  const onStartedMock = jest.fn();
+  const onStoppedMock = jest.fn();
+
+  const subscription = await new Promise<Unsubscribable>((resolve) => {
+    const subscription = trpc.throwSubscription.subscribe(
+      { payload: 'subscription1' },
+      {
+        onData: onDataMock,
+        onComplete: onCompleteMock,
+        onError: (error) => {
+          onErrorMock(error);
+          resolve(subscription);
+        },
+        onStarted: onStartedMock,
+        onStopped: onStoppedMock,
+      },
+    );
+  });
+
+  expect(onDataMock).toHaveBeenCalledTimes(0);
+  expect(onCompleteMock).toHaveBeenCalledTimes(0);
+  expect(onErrorMock).toHaveBeenCalledTimes(1);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  expect(onErrorMock.mock.calls[0][0].message).toEqual('subscription1');
+  expect(onStartedMock).toHaveBeenCalledTimes(0);
+  expect(onStoppedMock).toHaveBeenCalledTimes(0);
+  subscription.unsubscribe();
+  expect(onDataMock).toHaveBeenCalledTimes(0);
+  expect(onCompleteMock).toHaveBeenCalledTimes(0);
+  expect(onErrorMock).toHaveBeenCalledTimes(1);
+  expect(onStartedMock).toHaveBeenCalledTimes(0);
+  expect(onStoppedMock).toHaveBeenCalledTimes(0);
 });
 
 test('with nested subscription', async () => {

--- a/test/webextWTransfromer.test.ts
+++ b/test/webextWTransfromer.test.ts
@@ -3,6 +3,7 @@ import { resetMocks } from './__setup';
 import { createTRPCProxyClient } from '@trpc/client';
 import { initTRPC } from '@trpc/server';
 import { Unsubscribable, observable } from '@trpc/server/observable';
+import superjson from 'superjson';
 import { z } from 'zod';
 
 import { createChromeHandler } from '../src/adapter';
@@ -12,28 +13,45 @@ afterEach(() => {
   resetMocks();
 });
 
-const t = initTRPC.create();
+const t = initTRPC.create({ transformer: superjson });
 
 const appRouter = t.router({
-  echoQuery: t.procedure.input(z.object({ payload: z.string() })).query(({ input }) => input),
-  echoMutation: t.procedure.input(z.object({ payload: z.string() })).mutation(({ input }) => input),
-  echoSubscription: t.procedure.input(z.object({ payload: z.string() })).subscription(({ input }) =>
-    observable<typeof input>((emit) => {
-      emit.next(input);
-    }),
-  ),
+  echoQuery: t.procedure
+    .input(z.object({ payload: z.string(), date: z.date() }))
+    .query(({ input }) => input),
+  echoMutation: t.procedure
+    .input(z.object({ payload: z.string(), date: z.date() }))
+    .mutation(({ input }) => input),
+  echoSubscription: t.procedure
+    .input(z.object({ payload: z.string(), date: z.date() }))
+    .subscription(({ input }) =>
+      observable<typeof input>((emit) => {
+        emit.next(input);
+      }),
+    ),
+
+  echoTransformerQuery: t.procedure
+    .input(z.object({ payload: z.date() }))
+    .query(({ input }) => input),
+
   nestedRouter: t.router({
-    echoQuery: t.procedure.input(z.object({ payload: z.string() })).query(({ input }) => input),
+    echoQuery: t.procedure
+      .input(z.object({ payload: z.string(), date: z.date() }))
+      .query(({ input }) => input),
     echoMutation: t.procedure
-      .input(z.object({ payload: z.string() }))
+      .input(z.object({ payload: z.string(), date: z.date() }))
       .mutation(({ input }) => input),
     echoSubscription: t.procedure
-      .input(z.object({ payload: z.string() }))
+      .input(z.object({ payload: z.string(), date: z.date() }))
       .subscription(({ input }) =>
         observable((emit) => {
           emit.next(input);
         }),
       ),
+
+    echoTransformerQuery: t.procedure
+      .input(z.object({ payload: z.date() }))
+      .query(({ input }) => input),
   }),
 });
 
@@ -46,20 +64,29 @@ test('with query', async () => {
   const port = chrome.runtime.connect();
   const trpc = createTRPCProxyClient<typeof appRouter>({
     links: [chromeLink({ port })],
+    transformer: superjson,
   });
 
-  const data1 = await trpc.echoQuery.query({ payload: 'query1' });
-  expect(data1).toEqual({ payload: 'query1' });
+  // 2023-11-17 08:00:00 utc
+  const date1 = new Date(1700208000000);
+  const data1 = await trpc.echoQuery.query({ payload: 'query1', date: date1 });
+  expect(data1).toEqual({ payload: 'query1', date: date1 });
 
-  const data2 = await trpc.nestedRouter.echoQuery.query({ payload: 'query2' });
-  expect(data2).toEqual({ payload: 'query2' });
+  // 2023-11-20 08:00:00 utc
+  const date2 = new Date(1700467200000);
+  const data2 = await trpc.nestedRouter.echoQuery.query({ payload: 'query2', date: date2 });
+  expect(data2).toEqual({ payload: 'query2', date: date2 });
 
+  // 2022-11-20 08:00:00 utc
+  const date3 = new Date(1668931200000);
+  // 2021-11-20 08:00:00 utc
+  const date4 = new Date(1637395200000);
   const [data3, data4] = await Promise.all([
-    trpc.echoQuery.query({ payload: 'query3' }),
-    trpc.echoQuery.query({ payload: 'query4' }),
+    trpc.echoQuery.query({ payload: 'query3', date: date3 }),
+    trpc.echoQuery.query({ payload: 'query4', date: date4 }),
   ]);
-  expect(data3).toEqual({ payload: 'query3' });
-  expect(data4).toEqual({ payload: 'query4' });
+  expect(data3).toEqual({ payload: 'query3', date: date3 });
+  expect(data4).toEqual({ payload: 'query4', date: date4 });
 });
 
 test('with mutation', async () => {
@@ -71,20 +98,29 @@ test('with mutation', async () => {
   const port = chrome.runtime.connect();
   const trpc = createTRPCProxyClient<typeof appRouter>({
     links: [chromeLink({ port })],
+    transformer: superjson,
   });
 
-  const data1 = await trpc.echoMutation.mutate({ payload: 'mutation1' });
-  expect(data1).toEqual({ payload: 'mutation1' });
+  // 2023-11-17 08:00:00 utc
+  const date1 = new Date(1700208000000);
+  const data1 = await trpc.echoMutation.mutate({ payload: 'mutation1', date: date1 });
+  expect(data1).toEqual({ payload: 'mutation1', date: date1 });
 
-  const data2 = await trpc.nestedRouter.echoMutation.mutate({ payload: 'mutation2' });
-  expect(data2).toEqual({ payload: 'mutation2' });
+  // 2023-11-20 08:00:00 utc
+  const date2 = new Date(1700467200000);
+  const data2 = await trpc.nestedRouter.echoMutation.mutate({ payload: 'mutation2', date: date2 });
+  expect(data2).toEqual({ payload: 'mutation2', date: date2 });
 
+  // 2022-11-20 08:00:00 utc
+  const date3 = new Date(1668931200000);
+  // 2021-11-20 08:00:00 utc
+  const date4 = new Date(1637395200000);
   const [data3, data4] = await Promise.all([
-    trpc.echoMutation.mutate({ payload: 'mutation3' }),
-    trpc.echoMutation.mutate({ payload: 'mutation4' }),
+    trpc.echoMutation.mutate({ payload: 'mutation3', date: date3 }),
+    trpc.echoMutation.mutate({ payload: 'mutation4', date: date4 }),
   ]);
-  expect(data3).toEqual({ payload: 'mutation3' });
-  expect(data4).toEqual({ payload: 'mutation4' });
+  expect(data3).toEqual({ payload: 'mutation3', date: date3 });
+  expect(data4).toEqual({ payload: 'mutation4', date: date4 });
 });
 
 test('with subscription', async () => {
@@ -96,6 +132,7 @@ test('with subscription', async () => {
   const port = chrome.runtime.connect();
   const trpc = createTRPCProxyClient<typeof appRouter>({
     links: [chromeLink({ port })],
+    transformer: superjson,
   });
 
   const onDataMock = jest.fn();
@@ -103,9 +140,12 @@ test('with subscription', async () => {
   const onErrorMock = jest.fn();
   const onStartedMock = jest.fn();
   const onStoppedMock = jest.fn();
+
+  // 2023-11-17 08:00:00 utc
+  const date1 = new Date(1700208000000);
   const subscription = await new Promise<Unsubscribable>((resolve) => {
     const subscription = trpc.echoSubscription.subscribe(
-      { payload: 'subscription1' },
+      { payload: 'subscription1', date: date1 },
       {
         onData: (data) => {
           onDataMock(data);
@@ -119,7 +159,7 @@ test('with subscription', async () => {
     );
   });
   expect(onDataMock).toHaveBeenCalledTimes(1);
-  expect(onDataMock).toHaveBeenNthCalledWith(1, { payload: 'subscription1' });
+  expect(onDataMock).toHaveBeenNthCalledWith(1, { payload: 'subscription1', date: date1 });
   expect(onCompleteMock).toHaveBeenCalledTimes(0);
   expect(onErrorMock).toHaveBeenCalledTimes(0);
   expect(onStartedMock).toHaveBeenCalledTimes(1);
@@ -141,6 +181,7 @@ test('with nested subscription', async () => {
   const port = chrome.runtime.connect();
   const trpc = createTRPCProxyClient<typeof appRouter>({
     links: [chromeLink({ port })],
+    transformer: superjson,
   });
 
   const onDataMock = jest.fn();
@@ -148,9 +189,12 @@ test('with nested subscription', async () => {
   const onErrorMock = jest.fn();
   const onStartedMock = jest.fn();
   const onStoppedMock = jest.fn();
+
+  // 2023-11-20 08:00:00 utc
+  const date1 = new Date(1700467200000);
   const subscription = await new Promise<Unsubscribable>((resolve) => {
     const subscription = trpc.nestedRouter.echoSubscription.subscribe(
-      { payload: 'subscription1' },
+      { payload: 'subscription1', date: date1 },
       {
         onData: (data) => {
           onDataMock(data);
@@ -164,7 +208,7 @@ test('with nested subscription', async () => {
     );
   });
   expect(onDataMock).toHaveBeenCalledTimes(1);
-  expect(onDataMock).toHaveBeenNthCalledWith(1, { payload: 'subscription1' });
+  expect(onDataMock).toHaveBeenNthCalledWith(1, { payload: 'subscription1', date: date1 });
   expect(onCompleteMock).toHaveBeenCalledTimes(0);
   expect(onErrorMock).toHaveBeenCalledTimes(0);
   expect(onStartedMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- add transformer serialization to emitted data in subscription routes
- added tests for query, mutate, and subscription routes using a custom transformer